### PR TITLE
Add a custom column displaying `TotalPrice`

### DIFF
--- a/app/travel_processor/webapp/ext/MyTotalPrice.fragment.xml
+++ b/app/travel_processor/webapp/ext/MyTotalPrice.fragment.xml
@@ -1,0 +1,6 @@
+<core:FragmentDefinition xmlns:core="sap.ui.core" xmlns="sap.m">
+    <Text 
+        id="myTotalPrice"
+        text="{TotalPrice}"
+    />
+  </core:FragmentDefinition>

--- a/app/travel_processor/webapp/manifest.json
+++ b/app/travel_processor/webapp/manifest.json
@@ -126,6 +126,16 @@
               "controlConfiguration": {
                 "@com.sap.vocabularies.UI.v1.SelectionFields": {
                   "useSemanticDateRange": true
+                },
+                "@com.sap.vocabularies.UI.v1.LineItem": {
+                  "columns": {
+                    "myTotalPrice": {
+                      "id": "myTotalPrice",
+                      "header": "Total Price (Custom Column)",
+                      "template": "sap.fe.cap.travel.ext.MyTotalPrice",
+                      "properties": ["TotalPrice"]
+                    }
+                  }
                 }
               },
               "variantManagement": "Page",


### PR DESCRIPTION
## Description

Add a [custom column](https://sapui5.hana.ondemand.com/sdk/#/topic/d525522c1bf54672ae4e02d66b38e60c.html): **Total Price (Custom Column)**, displaying `TotalPrice`, and specify `["TotalPrice"]` as its `properties` for Sorting and Export to spreadsheet.

<img width="1780" alt="Screenshot 2023-09-26 at 14 46 03" src="https://github.com/PierreFritsch/cap-sflight/assets/10234267/0623f099-ef66-46ac-af61-b0e93c315cfe">

## Issue Description

When I run the server locally: 

```
git clone https://github.com/PierreFritsch/cap-sflight
cd cap-sflight
git checkout ExportCustomColumn
npm install
cds watch
```

and I access the *Travel Processor* app: http://localhost:4004/travel_processor/webapp/index.html
and I log in with user `amy`, no password
and I click the button **Export Table (Cmd+Shift+E)** at the top-right corner of the **Travels** table
then the Excel export works:

<img width="1160" alt="Screenshot 2023-09-26 at 14 47 01" src="https://github.com/PierreFritsch/cap-sflight/assets/10234267/fac747dd-d95b-4adc-a4c0-b0097373163a">

... but Excel interprets the custom column *as a String*. For instance, if I attempt to add a calculation to another cell, based on the contents of the column *Total Price (Custom Column)*, then Excel displays `#VALUE`. Note that this works fine for the contents of the "standard" column *Total Price* - it is possible to perform calculations on this standard column. 

<img width="575" alt="Screenshot 2023-09-26 at 14 47 44" src="https://github.com/PierreFritsch/cap-sflight/assets/10234267/8f951288-20ed-4a6c-bcad-8d64800c1723">

I would expect that, for a custom column based on a number property, the standard *export to spreadsheet* function renders a column that Excel interprets as a number.

## Version Information

The issue occurred with **`sap.ui.version` `1.117.0`** on:

- Safari Version 16.6 (18615.3.12.11.2)
- Microsoft Excel for Mac Version 16.77 (23091003)

`cds v -i` reported:

| @capire/sflight | https://github.com/SAP-samples/cap-sflight |
|:---------------------- | ----------- |
| CAP Java Runtime       | -- missing  |
| @sap/cds-compiler      | 4.0.2       |
| @sap/cds-dk            | -- missing  |
| @sap/cds-dk (global)   | 7.0.3       |
| @sap/eslint-plugin-cds | 2.6.3       |
| @sap/cds-mtxs          | 1.9.2       |
