### PR TITLE
Prevent the deletion of Travels

### DIFF
--- a/db/schema.cds
+++ b/db/schema.cds
@@ -22,6 +22,7 @@ entity Travel : managed {
   to_Agency      : Association to TravelAgency;
   to_Customer    : Association to Passenger;
   to_Booking     : Composition of many Booking on to_Booking.to_Travel = $self;
+  isDeletable    : Boolean default false;
 };
 
 annotate Travel with @(

--- a/srv/travel-service.cds
+++ b/srv/travel-service.cds
@@ -8,7 +8,7 @@ service TravelService @(path:'/processor') {
     { grant: ['*'], to: 'processor'},
     { grant: ['*'], to: 'admin'}
   ])
-  @Capabilities.DeleteRestrictions: {Deletable: isDeletable}
+  @Capabilities.DeleteRestrictions: {Deletable: false}
   entity Travel as projection on my.Travel actions {
     action createTravelByTemplate() returns Travel;
     action rejectTravel();

--- a/srv/travel-service.cds
+++ b/srv/travel-service.cds
@@ -8,6 +8,7 @@ service TravelService @(path:'/processor') {
     { grant: ['*'], to: 'processor'},
     { grant: ['*'], to: 'admin'}
   ])
+  @Capabilities.DeleteRestrictions: {Deletable: isDeletable}
   entity Travel as projection on my.Travel actions {
     action createTravelByTemplate() returns Travel;
     action rejectTravel();

--- a/srv/travel-service.cds
+++ b/srv/travel-service.cds
@@ -8,7 +8,7 @@ service TravelService @(path:'/processor') {
     { grant: ['*'], to: 'processor'},
     { grant: ['*'], to: 'admin'}
   ])
-  @Capabilities.DeleteRestrictions: {Deletable: false}
+  @Capabilities.DeleteRestrictions: {Deletable: isDeletable}
   entity Travel as projection on my.Travel actions {
     action createTravelByTemplate() returns Travel;
     action rejectTravel();


### PR DESCRIPTION
## Description

Prevent the deletion of Travels, as [documented](https://learning.sap.com/learning-journey/developing-an-sap-fiori-elements-app-based-on-a-cap-odata-v4-service/applying-generic-actions-provided-by-sap-fiori-elements_ee9f52af-318a-4979-a8b5-929c5edebbee#) in the SAP Learning Journey "Applying Generic Actions Provided by SAP Fiori Elements":

> You can also disable the delete action for specific items by assigning a path to the Deletable property that points to a particular Boolean property of the entity.

```cds
annotate TravelService.Travel with @( 
  Capabilities.DeleteRestrictions : { 
    $Type : 'Capabilities.DeleteRestrictionsType', 
    Deletable: TravelStatus.insertDeleteRestriction 
  } 
); 
```

## Screenshot

Notice that the **Delete** button is disabled.

![Screenshot 2023-10-05 at 15 34 42](https://github.com/PierreFritsch/cap-sflight/assets/10234267/0e0a6471-49b4-4f0e-bbca-e6ea9e9859a5)
